### PR TITLE
benchmarks: Add benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ with C easier. These could include:
 * Hash tables
 * Self-sizing strings
 
+### Performance
+
+`µlib` contains a work-in-progress benchmark suite that compares its performance
+against the widely use [GLib](https://wiki.gnome.org/Projects/GLib)
+cross-platform, low-level C library. Currently, the performance of creating a
+new singly-linked list of 2<sup>16</sup> integers is as follows:
+
+|`µlib`           | GLib            |
+|-----------------|-----------------|
+| `real	0m6.648s` | `real 0m3.091s` |
+| `user	0m6.632s` | `user 0m3.078s` |
+| `sys	0m0.004s` | `sys 0m0.006s`  |
+
+The measurements were run against GLib 2.66.7 with the Linux `time` utility.
+
 ### Installation
 
 `µlib` has no dependencies outside of the C standard library. Currently, it's

--- a/benchmark/benchmark-gslist.c
+++ b/benchmark/benchmark-gslist.c
@@ -1,0 +1,34 @@
+/* benchmark-gslist.c
+ *
+ * Copyright 2021 Joshua Lee <lee.son.wai@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <glib.h>
+#include <stdio.h>
+
+int
+main (int    argc,
+      char **argv)
+{
+  GSList *list;
+
+  for (int i = 0; i < 65536; i++)
+    list = g_slist_append (list, GINT_TO_POINTER (i));
+
+  return 0;
+}

--- a/benchmark/benchmark-mu-slist.c
+++ b/benchmark/benchmark-mu-slist.c
@@ -1,0 +1,36 @@
+/* benchmark-mu-slist.c
+ *
+ * Copyright 2021 Joshua Lee <lee.son.wai@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+
+#include "mu-slist.h"
+
+int
+main (int    argc,
+      char **argv)
+{
+  MuSList *list;
+
+  list = mu_slist_new ((void *) (long) 0);
+  for (int i = 1; i < 65536; i++)
+    list = mu_slist_append (list, (void *) (long) (i));
+
+  return 0;
+}

--- a/benchmark/meson.build
+++ b/benchmark/meson.build
@@ -1,0 +1,24 @@
+benchmark_incs = include_directories('../src/')
+
+mulib_benchmark = shared_library('mulib-benchmark', mulib_src,
+  include_directories: benchmark_incs,
+  install: false
+)
+
+glib_dep = dependency('glib-2.0', version: '>= 2.55.0')
+mu_dep = [
+  declare_dependency(
+    include_directories: benchmark_incs,
+    link_with: mulib_benchmark
+  )
+]
+
+gslist_benchmark = executable('gslist', 'benchmark-gslist.c',
+  dependencies: glib_dep
+)
+mu_slist_benchmark = executable('slist', 'benchmark-mu-slist.c',
+  dependencies: mu_dep
+)
+
+benchmark('gslist benchmark', gslist_benchmark)
+benchmark('mu-list benchmark', mu_slist_benchmark)

--- a/meson.build
+++ b/meson.build
@@ -17,3 +17,4 @@ add_project_arguments(
 
 subdir('src')
 subdir('tests')
+subdir('benchmark')


### PR DESCRIPTION
This adds a benchmark target that can be enabled by configuring the 'benchmark'
option before building. It runs a basic comparison of mulib's data types
against those of the popular GLib C library.